### PR TITLE
增加 JitPack 构建配置

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
指定了 JitPack 所用的 JDK 版本，因为依赖 `moduleplugin` 由 JDK 11 所编译，导致最新版本[构建失败](https://jitpack.io/com/github/glavo/gjavah/0.2.0/build.log)。